### PR TITLE
SGSCO-373 patch mockgun _compare method - add duration field_type

### DIFF
--- a/shotgun_api3/lib/mockgun/mockgun.py
+++ b/shotgun_api3/lib/mockgun/mockgun.py
@@ -603,7 +603,7 @@ class Shotgun(object):
                 return lval == rval
             elif operator == "is_not":
                 return lval != rval
-        elif field_type in ("float", "number", "date", "date_time"):
+        elif field_type in ("float", "number", "date", "date_time", "duration"):
             if operator == "is":
                 return lval == rval
             elif operator == "is_not":


### PR DESCRIPTION
- Add `duration` `field_type` for `_compare` method - needed for unit tests with `TimeLog` entities.

### **Note:**
- This is a forked `python-api` repo from `shotgunsoftware` to `thr3dcgi`.
- `main` and `dev` branches were created, based on the original `master` branch. `dev` was set as the default base branch for our development purposes and Jira automation.

### **Important:**
_When creating a new pull request, pay close attention to the "Base Repository" and "base" branch selectors!_

**Example:**
- When creating this PR, I had to first select from "Choose a Repository"  and select the `thr3dcgi` forked repo - not the original `shotgunsoftware` repo!
- Then, I chose the "base" branch, which was `dev`, in this case.